### PR TITLE
Fix isPlotOwner() on modern Towny versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.acrobot.chestshop.towny</groupId>
     <artifactId>chestshop-towny</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4</version>
     <name>ChestShop-towny</name>
 
     <properties>

--- a/src/main/java/com/acrobot/chestshop/towny/Permission.java
+++ b/src/main/java/com/acrobot/chestshop/towny/Permission.java
@@ -22,10 +22,6 @@ public enum Permission {
         return player.hasPermission(node) || player.hasPermission(node.toLowerCase());
     }
 
-    private static boolean hasPermissionSet(Player p, String perm) {
-        return p.isPermissionSet(perm) && p.hasPermission(perm);
-    }
-
     public String toString() {
         return permission;
     }

--- a/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
+++ b/src/main/java/com/acrobot/chestshop/towny/TownyUtils.java
@@ -53,6 +53,7 @@ public class TownyUtils {
             TownBlockOwner owner = TownyAPI.getInstance().getDataSource().getResident(player.getName());
             return TownyAPI.getInstance().getTownBlock(location).isOwner(owner);
         } catch (NotRegisteredException ex) {
+            // NRE is no longer thrown in modern Towny, keep this until the POM has the Towny version updated.
             return false;
         }
     }
@@ -65,7 +66,7 @@ public class TownyUtils {
      */
     public static boolean isPlotOwner(Player player, Location... locations) {
         for (Location location : locations) {
-            if (!isPlotOwner(player, location)) {
+            if (isInWilderness(location) || !isPlotOwner(player, location)) {
                 return false;
             }
         }


### PR DESCRIPTION
Towny no longer throws NotRegisteredExceptions for TownyAPI.getInstance().getTownBlock(location), which requires that we check if the location is not in the wilderness.